### PR TITLE
Remove deprecation and ember-cli-babel dependency

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,0 @@
-import Ember from 'ember';
-
-Ember.deprecate("ember-string-ishtmlsafe-polyfill is now a true polyfill. Use Ember.String.isHTMLSafe directly instead of importing from ember-string-ishtmlsafe-polyfill", false, {
-  id: "ember-string-ishtmlsafe-polyfill.import",
-  until: '2.0.0'
-});
-
-export default Ember.String.isHTMLSafe;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
     "ember-cli-version-checker": "^1.2.0"
   },
   "devDependencies": {
@@ -28,6 +27,7 @@
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
+    "ember-cli-babel": "^5.1.7",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",

--- a/tests/unit/string-ishtmlsafe-test.js
+++ b/tests/unit/string-ishtmlsafe-test.js
@@ -1,21 +1,7 @@
 import { module, test } from 'qunit';
 import Ember from 'ember';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 module('Unit | isHTMLSafe');
-
-test('Imported isHTMLSafe() function properly detects safe strings', function(assert) {
-  let plainStr = 'Hello World',
-      htmlSafeStr = Ember.String.htmlSafe(plainStr);
-
-  assert.notOk(isHTMLSafe(plainStr), 'Plain string is not html safe string');
-  assert.ok(isHTMLSafe(htmlSafeStr), 'Html safe string matches');
-
-  assert.notOk(isHTMLSafe([]), 'Array is not html safe string');
-  assert.notOk(isHTMLSafe({}), 'Object is not html safe string');
-  assert.notOk(isHTMLSafe(10), 'Number is not html safe string');
-  assert.notOk(isHTMLSafe(null), 'Null is not html safe string');
-});
 
 test('"Native" Ember.String.isHTMLSafe() function properly detects safe strings', function(assert) {
   let plainStr = 'Hello World',


### PR DESCRIPTION
The `ember-cli-babel` dependency is essentially unnecessary if and addon has no `app` and `addon` folders, and since the `addon` folder only contains the deprecated import redirection it's probably time to remove it :)

/cc @workmanw 