### PR TITLE
Bump version of ember-cli-dependency-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",


### PR DESCRIPTION
The old ember-cli-dependency-checker lead to a deprecation warning in ember 2.18, see also https://github.com/offirgolan/ember-cp-validations/issues/559