### PR TITLE
Change to use Chrome for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
 
 before_install:
   - npm config set spin false
+  - npm install -g bower
   - bower --version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ node_js:
 
 sudo: false
 
+addons:
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
+
+
 cache:
   directories:
     - $HOME/.npm
@@ -36,9 +44,7 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower phantomjs-prebuilt
   - bower --version
-  - phantomjs --version
 
 install:
   - npm install

--- a/testem.js
+++ b/testem.js
@@ -1,13 +1,24 @@
-/*jshint node:true*/
 module.exports = {
-  "framework": "qunit",
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "launch_in_ci": [
-    "PhantomJS"
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'Chrome'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
-  ]
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ].filter(Boolean)
+    }
+  }
 };


### PR DESCRIPTION
I think the tests were failing for https://github.com/workmanw/ember-string-ishtmlsafe-polyfill/pull/7 because of phantomjs failing with some newer JavaScript features.

This changes to use Chrome like newer ember-cli addons do it. Let's see if travis passes…